### PR TITLE
Update requirements.txt, remove `pkg-resources`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ bs4==0.0.1
 certifi==2020.6.20
 chardet==3.0.4
 idna==2.10
-pkg-resources==0.0.0
 requests==2.24.0
 soupsieve==2.0.1
 urllib3==1.25.9


### PR DESCRIPTION
removed `pkg-resources` dependency, which apparently gets added by Ubuntu when using virtualenvs.
see https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command